### PR TITLE
Remove empty anchors

### DIFF
--- a/themes/ovh/static/css/guides.css
+++ b/themes/ovh/static/css/guides.css
@@ -97,12 +97,12 @@
   cursor: pointer;
 }
 
-#content h1:hover::after,
-#content h2:hover::after,
-#content h3:hover::after,
-#content h4:hover::after,
-#content h5:hover::after,
-#content h6:hover::after {
+#content h1:not(:empty):hover::after,
+#content h2:not(:empty):hover::after,
+#content h3:not(:empty):hover::after,
+#content h4:not(:empty):hover::after,
+#content h5:not(:empty):hover::after,
+#content h6:not(:empty):hover::after {
   font-family: 'Font Awesome 5 Free';
   font-weight: 900;
   content: '\f0c1';


### PR DESCRIPTION
`##` where creating `<h2>` resulting in useless anchors.

But simply removing the `##` was also removing the padding.

I just changed the css rule to prevent empty `<h2>` from shifting the whole page.

**Before:**
<img width="845" alt="image" src="https://user-images.githubusercontent.com/3717331/125637817-73816473-b7ed-4d74-b22e-158733e13ab7.png">

**After:**
<img width="743" alt="image" src="https://user-images.githubusercontent.com/3717331/125637896-f99e79b2-28fe-4f84-925e-ab695bef4bed.png">
