### PR TITLE
Add bottom margin to tabs

### DIFF
--- a/themes/ovh/static/css/main.css
+++ b/themes/ovh/static/css/main.css
@@ -3749,6 +3749,7 @@ table.hover tbody tr:nth-of-type(even):hover {
 .tabs-content {
   background: #fefefe;
   transition: all 0.5s ease;
+  margin-bottom: 1rem;
   border: 1px solid #e6e6e6;
   border-top: 0; }
 


### PR DESCRIPTION
To make paragraph following the tab block more readable.

**Note**: the tab blocks on the rendered pages are identified with class `ovh__tabs` (and not `tabs`), so to make this PR simpler I added the margin to the `tabs-content` block, for the same result.
The alternative would be to rename the `tabs` CSS block into `ovh__tabs` and add margin there, but it could have other implications I do not know about.

### Before

![](https://dl.plik.ovh/file/ozlDN5Z3gPIoNEYa/B3yYOLEQtqcDhKlQ/without%20space.png)

### After

![](https://dl.plik.ovh/file/ozlDN5Z3gPIoNEYa/TDtwwo4Rm6pXhogm/with%20space.png)