### PR TITLE
fix(thumbnail): use border instead of box-shadow to avoid box-shadow …

### DIFF
--- a/themes/ovh/static/css/fix.css
+++ b/themes/ovh/static/css/fix.css
@@ -369,6 +369,15 @@ ul.ods-footer__menu {
   font-weight: normal!important;
 }
 
+/* Fix firefox box-shadow zoom-out issue */
+.thumbnail {
+  box-shadow: none;
+  border: solid 1px rgba(10, 10, 10, 0.2);
+  transition-property: box-shadow, border-color;
+}
+.thumbnail:hover, .thumbnail:focus {
+  border-color: #fefefe;
+}
 
 /*
 ===========================================


### PR DESCRIPTION
…disappearing when zoomed-out in firefox.